### PR TITLE
fixed single lookup v3 endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crunchbase-api",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A node.js library for accessing the CrunchBase REST API",
   "main": "index.js",
   "license": "Apache-2.0",
@@ -66,6 +66,11 @@
     },
     {
       "name": "CodingHouse 2014 Winter Cohort"
+    },
+    {
+      "name": "Michael Hirn",
+      "email": "mj@autumnai.com",
+      "url": :https://github.com/MichaelHirn"
     }
   ],
   "engines": {

--- a/util/url_helper.js
+++ b/util/url_helper.js
@@ -31,7 +31,7 @@ function getOrganizationsUrl(params) {
 
 function getOrganizationUrl(permalink) {
   return endpoint
-  + 'organization/' + permalink + keyParam;
+  + 'organizations/' + permalink + keyParam;
 }
 
 function getPeopleUrl(page){
@@ -42,7 +42,7 @@ function getPeopleUrl(page){
 
 function getPersonUrl(permalink){
   return endpoint
-  + 'person/' + permalink + keyParam;
+  + 'people/' + permalink + keyParam;
 }
 
 function getProductsUrl(params) {
@@ -53,7 +53,7 @@ function getProductsUrl(params) {
 
 function getProductUrl(permalink) {
   return endpoint
-  + 'product/' + permalink + keyParam;
+  + 'products/' + permalink + keyParam;
 }
 
 function getFundingRoundUrl(uuid) {


### PR DESCRIPTION
Links for org, people and product lookups differed from the current docs (https://data.crunchbase.com/) and returned an HTML error page instead of the expected JSON.

This PR fixes that
